### PR TITLE
Change pet image style and fix blue underline bug

### DIFF
--- a/src/components/PetCard.css
+++ b/src/components/PetCard.css
@@ -13,32 +13,18 @@
 }
 
 .pet-image-container {
-    display: grid;
-    grid-template-columns: repeat(36, 1fr);
+    display: flex;
     position: relative;
     width: 80%;
   }
 
 
-.foreground-image {
-    position: absolute;
-    grid-column: 1 / span 35;
-    grid-row: 1; 
-    z-index: 1;
-}
-
-.background-image {
-    grid-column: 2 / -1;
-    grid-row: 1;
-    padding-top: 5%; 
-    box-shadow: #E63946 5px 5px 5px, inset #E63946  10px 10px 50px;
-    border-radius: 2px;
-}
-
 .pet-image {
     width: 100%;
     display: block;
     border: solid 1px #1D3557;
+    box-shadow: #E63946 5px 5px 5px, inset #E63946  10px 10px 50px;
+    border-radius: 2px;
 
 }
 

--- a/src/components/PetCard.jsx
+++ b/src/components/PetCard.jsx
@@ -20,11 +20,8 @@ const PetCard = ({pet}) => {
                     <img className="banner-picture" src="../images/banner.png"/>
                 </div>}
 
-                <div className="background-image">
-                    <img className="pet-image" src={`../images/${pet.id}.jpg`}></img>
-                </div>
-                <div className="foreground-image">
-                    <img className = "pet-image" src={`../images/${pet.id}.jpg`} alt = {`Image of ${pet.name} the lost ${pet.type}.`}></img>
+                <div>
+                    <img className="pet-image" src={`../images/${pet.id}.jpg`} alt={`${pet.name} the lost ${pet.type}.`}></img>
                 </div>
             </div>
             <div className = "pet-card-text"><p>{pet.name}, {pet.location}</p></div>

--- a/src/components/pages/LostPets.css
+++ b/src/components/pages/LostPets.css
@@ -3,7 +3,7 @@
     text-shadow: 2px 1px 1px #E63946;
 }
 
-.petCardsContainer {
+.pet-cards-container {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr 1fr;
     grid-gap: 0.7rem;
@@ -15,6 +15,10 @@
     border-radius: 12px;
     position: relative;
     z-index: 0;
+}
+
+.pet-cards-container a {
+    text-decoration: unset;
 }
 
 .lost-pets-layout {

--- a/src/components/pages/LostPets.js
+++ b/src/components/pages/LostPets.js
@@ -129,7 +129,7 @@ const LostPets = () => {
             </div>
           </FilterContainer>
 
-          <div className="petCardsContainer">
+          <div className="pet-cards-container">
             {petsToDisplay.map((pet) => (
               <PetCard key={pet.id} pet={pet} />
             ))}

--- a/src/components/pages/PetInfo.css
+++ b/src/components/pages/PetInfo.css
@@ -25,55 +25,17 @@
 }
 
 .pet-info-image-container {
-    display: grid;
-    grid-template-columns: repeat(36, 1fr);
+    display: flex;
     position: relative;
     width: 300px;
   }
-
-  .return-to-pets-button {
-    background-color: #e63946;
-    border-radius: 78px;
-    border: none;
-    width: 150px;
-    height: 35px;
-    flex-shrink: 0;
-    box-shadow: 1px 1px 0 0 #1D3557;
-    border-color: #e63946;
-    color: var(--White, #FFF); 
-    text-align: center;
-    font-family: "Roboto-Regular", Helvetica;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: normal;
-    transition: background-color 0.3s, color 0.3s;
-  }
-  
-  .return-to-pets-button:hover {
-    background-color: var(--White, #FFF); 
-    color: #e63946; 
-  }
-  
-.pet-info-foreground-image {
-    position: absolute;
-    grid-column: 1 / span 35;
-    grid-row: 1; 
-    z-index: 1;
-}
-
-.pet-info-background-image {
-    grid-column: 2 / -1;
-    grid-row: 1;
-    padding-top: 5%; 
-    box-shadow: #E63946 5px 5px 5px, inset #E63946  10px 10px 50px;
-    border-radius: 2px;
-}
 
 .pet-info-image {
     width: 100%;
     display: block;
     border: solid 1px #1D3557;
+    box-shadow: #E63946 5px 5px 5px, inset #E63946  10px 10px 50px;
+    border-radius: 2px;
 
 }
 

--- a/src/components/pages/PetInfo.js
+++ b/src/components/pages/PetInfo.js
@@ -17,12 +17,7 @@ const PetInfo = () => {
           <h1>Details</h1>
           <div className="pet-info-container">
               <div className = "pet-info-image-container">
-                    <div className="pet-info-background-image">
-                        <img className="pet-info-image" src={`../images/${pet.id}.jpg`}></img>
-                    </div>
-                    <div className="pet-info-foreground-image">
-                        <img className = "pet-info-image" src={`../images/${pet.id}.jpg`} alt = {`Image of ${pet.name} the lost ${pet.type}.`}></img>
-                    </div>
+                  <img className = "pet-info-image" src={`../images/${pet.id}.jpg`} alt = {`${pet.name} the lost ${pet.type}.`}></img>
               </div>
             <div className = "pet-info-details-container">
               <p><span className="pet-info-details-keys">Pet's name: </span><span className="pet-info-details-values">{pet.name}</span></p>


### PR DESCRIPTION
## Motivation
- Initially the figma design had pet images displayed in a way where it appeared that there were two on top of each other. This was initially implemented in the app. However, we have established that we will not currently be adding functionality for multiple pictures and this styling choice is adding complication and causing bugs e.g. with some size pictures not displaying correctly.

## Core changes
- Changes pet images so that now both on 'lost pets' and 'pet info' only one image with a box shadow is displayed.
- Fixed bug where pet names were underlined in blue